### PR TITLE
Put plugin behaviour behind settings

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/src/main/kotlin/me/sciberras/christian/pvs/BackgroundPostProjectStartupActivity.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/BackgroundPostProjectStartupActivity.kt
@@ -1,0 +1,48 @@
+package me.sciberras.christian.pvs
+
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+class BackgroundPostProjectStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        if (!this.pluginAlreadyEnabled(project) && this.projectDependsOnMultiplePhpVersions()) {
+            this.showEnablePluginRecommendation(project)
+        }
+    }
+
+    private fun pluginAlreadyEnabled(project: Project): Boolean {
+        return project.service<ProjectSettings>().state.enabled
+    }
+
+    private fun projectDependsOnMultiplePhpVersions(): Boolean {
+        // TODO Return true if:
+        //      - there must be multiple composer.json files (that are not in a vendor/ dir)
+        //      - at least 2 composer files have a different minimum php language level
+        return true
+    }
+
+    private fun showEnablePluginRecommendation(project: Project) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("PHP Version Switcher")
+            .createNotification(
+                Bundle.message("notifications.enable.title"),
+                Bundle.message("notifications.enable.content"),
+                NotificationType.INFORMATION
+            )
+            .setSuggestionType(true)
+            .addActions(
+                setOf(
+                    NotificationAction.createSimpleExpiring(Bundle.message("notifications.enable.enable")) {
+                        project.service<ProjectSettings>().state.enabled = true
+                    },
+                    NotificationAction.createSimpleExpiring(Bundle.message("notifications.enable.ignore")) {
+                    },
+                )
+            )
+            .notify(project);
+    }
+}

--- a/src/main/kotlin/me/sciberras/christian/pvs/BackgroundPostProjectStartupActivity.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/BackgroundPostProjectStartupActivity.kt
@@ -3,14 +3,22 @@ package me.sciberras.christian.pvs
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.jetbrains.php.config.PhpLanguageLevel
+
 
 class BackgroundPostProjectStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
-        if (!this.pluginAlreadyEnabled(project) && this.projectDependsOnMultiplePhpVersions()) {
-            this.showEnablePluginRecommendation(project)
+        ApplicationManager.getApplication().runReadAction {
+            if (!this.pluginAlreadyEnabled(project) && this.projectDependsOnMultiplePhpVersions(project)) {
+                this.showEnablePluginRecommendation(project)
+            }
         }
     }
 
@@ -18,12 +26,46 @@ class BackgroundPostProjectStartupActivity : ProjectActivity {
         return project.service<ProjectSettings>().state.enabled
     }
 
-    private fun projectDependsOnMultiplePhpVersions(): Boolean {
-        // TODO Return true if:
-        //      - there must be multiple composer.json files (that are not in a vendor/ dir)
-        //      - at least 2 composer files have a different minimum php language level
-        return true
+    private fun projectDependsOnMultiplePhpVersions(project: Project): Boolean {
+        val vendorPathRegex = Regex("""[/\\]vendor[/\\]""")
+        var lastPhpVersion: PhpLanguageLevel? = null
+        var differentVersions = false
+
+        FilenameIndex.processFilesByName(
+            "composer.json",
+            true,
+            GlobalSearchScope.projectScope(project)
+        ) { file: VirtualFile ->
+            // if the composer file is in some vendor directory, skip it
+            if (vendorPathRegex.matches(file.path)) {
+                return@processFilesByName true
+            }
+
+            val currentPhpVersion: PhpLanguageLevel? = file.findPhpVersion(project)
+
+            // if there is no php version, skip this file
+            if (currentPhpVersion == null) {
+                return@processFilesByName true
+            }
+
+            // if we have found a php version yet, take this one and continue
+            if (lastPhpVersion == null) {
+                lastPhpVersion = currentPhpVersion
+                return@processFilesByName true
+            }
+
+            // if the current php version does not match a previous one, stop here
+            if (lastPhpVersion?.name != currentPhpVersion.name) {
+                differentVersions = true
+                return@processFilesByName false
+            }
+
+            return@processFilesByName true
+        }
+
+        return differentVersions
     }
+
 
     private fun showEnablePluginRecommendation(project: Project) {
         NotificationGroupManager.getInstance()

--- a/src/main/kotlin/me/sciberras/christian/pvs/Bundle.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/Bundle.kt
@@ -1,0 +1,28 @@
+package me.sciberras.christian.pvs
+
+import com.intellij.DynamicBundle
+import org.jetbrains.annotations.Nls
+import org.jetbrains.annotations.NonNls
+import org.jetbrains.annotations.PropertyKey
+import java.util.function.Supplier
+
+@NonNls
+private const val BUNDLE = "messages.PVSBundle"
+
+internal object Bundle {
+    private val INSTANCE = DynamicBundle(Bundle::class.java, BUNDLE)
+
+    fun message(
+        key: @PropertyKey(resourceBundle = BUNDLE) String,
+        vararg params: Any
+    ): @Nls String {
+        return INSTANCE.getMessage(key, *params)
+    }
+
+    fun lazyMessage(
+        @PropertyKey(resourceBundle = BUNDLE) key: String,
+        vararg params: Any
+    ): Supplier<@Nls String> {
+        return INSTANCE.getLazyMessage(key, *params)
+    }
+}

--- a/src/main/kotlin/me/sciberras/christian/pvs/Extensions.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/Extensions.kt
@@ -1,0 +1,45 @@
+package me.sciberras.christian.pvs
+
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.openapi.diagnostic.currentClassLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.findPsiFile
+import com.jetbrains.php.config.PhpLanguageLevel
+import com.jetbrains.php.config.composer.LanguageLevelComposerParser
+import com.jetbrains.php.lang.inspections.PhpSwitchComposerLanguageLevelQuickFix
+
+internal val PHP_FILE_EXTS = arrayOf("php", "phtm", "phtml")
+
+fun VirtualFile.findPhpVersion(project: Project): PhpLanguageLevel? {
+    try {
+        return when {
+            this.name == "composer.json" -> {
+                LanguageLevelComposerParser
+                    .getMinRequiredLanguageLevel(
+                        this.findComposerPhpProperty(project),
+                        PhpLanguageLevel.PHP830
+                    )
+            }
+
+            this.name == "composer.lock" -> {
+                TODO("See: https://github.com/uuf6429/jetbrains-php-version-switcher/issues/4")
+            }
+
+            PHP_FILE_EXTS.contains(this.extension) -> {
+                TODO("See: https://github.com/uuf6429/jetbrains-php-version-switcher/issues/5")
+            }
+
+            else -> throw RuntimeException("")
+        }
+    } catch (ex: Throwable) {
+        currentClassLogger().error(ex)
+        return null
+    }
+}
+
+internal fun VirtualFile.findComposerPhpProperty(project: Project): String {
+    val psiFile = this.findPsiFile(project)
+    val jsonProp = PhpSwitchComposerLanguageLevelQuickFix.findPhpProperty(psiFile)?.value as JsonStringLiteral
+    return jsonProp.value
+}

--- a/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
@@ -1,6 +1,7 @@
 package me.sciberras.christian.pvs
 
 import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.currentClassLogger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.FocusChangeListener
@@ -16,6 +17,10 @@ import com.jetbrains.php.lang.inspections.PhpSwitchComposerLanguageLevelQuickFix
 
 internal class FocusChangeListener : FocusChangeListener {
     override fun focusGained(editor: Editor) {
+        if (editor.project?.service<ProjectSettings>()?.state?.enabled != TriState.ENABLED) {
+            return
+        }
+
         val phpFile = FileDocumentManager.getInstance().getFile(editor.document)
         if (phpFile == null || phpFile.fileType != PhpFileType.INSTANCE) {
             return

--- a/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
@@ -1,19 +1,14 @@
 package me.sciberras.christian.pvs
 
-import com.intellij.json.psi.JsonStringLiteral
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.currentClassLogger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.ex.FocusChangeListener
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.findPsiFile
 import com.jetbrains.php.config.PhpLanguageLevel
 import com.jetbrains.php.config.PhpProjectConfigurationFacade
-import com.jetbrains.php.config.composer.LanguageLevelComposerParser
 import com.jetbrains.php.lang.PhpFileType
-import com.jetbrains.php.lang.inspections.PhpSwitchComposerLanguageLevelQuickFix
 
 internal class FocusChangeListener : FocusChangeListener {
     override fun focusGained(editor: Editor) {
@@ -39,7 +34,7 @@ internal class FocusChangeListener : FocusChangeListener {
         }
         lastComposerFile = composerFile
 
-        val phpVersion = detectPhpVersion(composerFile, project)
+        val phpVersion = composerFile.findPhpVersion(project)
         if (phpVersion == null || phpVersion == lastPhpVersion) {
             return
         }
@@ -57,21 +52,6 @@ internal class FocusChangeListener : FocusChangeListener {
             }
         }
         return null
-    }
-
-    private fun detectPhpVersion(composerFile: VirtualFile, project: Project): PhpLanguageLevel? {
-        try {
-            val psiFile = composerFile.findPsiFile(project)
-            val jsonProp = PhpSwitchComposerLanguageLevelQuickFix.findPhpProperty(psiFile)?.value as JsonStringLiteral
-            return normalizePhpVersion(jsonProp.value)
-        } catch (ex: Throwable) {
-            currentClassLogger().error(ex)
-            return null
-        }
-    }
-
-    private fun normalizePhpVersion(version: String): PhpLanguageLevel? {
-        return LanguageLevelComposerParser.getMinRequiredLanguageLevel(version, PhpLanguageLevel.PHP830)
     }
 
     private fun setPhpVersion(project: Project, phpVersion: PhpLanguageLevel) {

--- a/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/FocusChangeListener.kt
@@ -17,7 +17,7 @@ import com.jetbrains.php.lang.inspections.PhpSwitchComposerLanguageLevelQuickFix
 
 internal class FocusChangeListener : FocusChangeListener {
     override fun focusGained(editor: Editor) {
-        if (editor.project?.service<ProjectSettings>()?.state?.enabled != TriState.ENABLED) {
+        if (editor.project?.service<ProjectSettings>()?.state?.enabled != true) {
             return
         }
 

--- a/src/main/kotlin/me/sciberras/christian/pvs/PhpLanguageLevelSwitcherService.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/PhpLanguageLevelSwitcherService.kt
@@ -9,8 +9,6 @@ import com.intellij.openapi.project.Project
 @Service(Service.Level.PROJECT)
 internal class PhpLanguageLevelSwitcherService(private val project: Project) : Disposable {
     init {
-        // TODO if setting is disabled, we should skip return here (and skip the rest)
-
         val eventMulticaster = EditorFactory.getInstance().eventMulticaster as? EditorEventMulticasterEx
         eventMulticaster?.addFocusChangeListener(FocusChangeListener(), this)
     }

--- a/src/main/kotlin/me/sciberras/christian/pvs/PostProjectStartupActivity.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/PostProjectStartupActivity.kt
@@ -3,7 +3,7 @@ package me.sciberras.christian.pvs
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 
-internal class ProjectActivity : ProjectActivity {
+internal class PostProjectStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         project.getService(PhpLanguageLevelSwitcherService::class.java)
     }

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
@@ -1,0 +1,20 @@
+package me.sciberras.christian.pvs
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.project.Project
+
+@Service(Service.Level.PROJECT)
+@State(name = "PVS.Settings", storages = [Storage(StoragePathMacros.PRODUCT_WORKSPACE_FILE)])
+class ProjectSettings(
+    private val project: Project,
+) : SimplePersistentStateComponent<ProjectSettingsState>(ProjectSettingsState())
+
+class ProjectSettingsState : BaseState() {
+    var enabled: TriState = TriState.UNDEFINED
+}
+
+enum class TriState {
+    ENABLED,
+    DISABLED,
+    UNDEFINED,
+}

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
@@ -1,20 +1,11 @@
 package me.sciberras.christian.pvs
 
 import com.intellij.openapi.components.*
-import com.intellij.openapi.project.Project
 
 @Service(Service.Level.PROJECT)
 @State(name = "PhpVersionSwitcher", storages = [Storage("pvs.xml")])
-class ProjectSettings(
-    private val project: Project,
-) : SimplePersistentStateComponent<ProjectSettingsState>(ProjectSettingsState())
+class ProjectSettings : SimplePersistentStateComponent<ProjectSettingsState>(ProjectSettingsState())
 
 class ProjectSettingsState : BaseState() {
-    var enabled: TriState by enum<TriState>(TriState.UNDEFINED)
-}
-
-enum class TriState {
-    ENABLED,
-    DISABLED,
-    UNDEFINED,
+    var enabled: Boolean by property(false)
 }

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettings.kt
@@ -4,13 +4,13 @@ import com.intellij.openapi.components.*
 import com.intellij.openapi.project.Project
 
 @Service(Service.Level.PROJECT)
-@State(name = "PVS.Settings", storages = [Storage(StoragePathMacros.PRODUCT_WORKSPACE_FILE)])
+@State(name = "PhpVersionSwitcher", storages = [Storage("pvs.xml")])
 class ProjectSettings(
     private val project: Project,
 ) : SimplePersistentStateComponent<ProjectSettingsState>(ProjectSettingsState())
 
 class ProjectSettingsState : BaseState() {
-    var enabled: TriState = TriState.UNDEFINED
+    var enabled: TriState by enum<TriState>(TriState.UNDEFINED)
 }
 
 enum class TriState {

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
@@ -3,17 +3,16 @@ package me.sciberras.christian.pvs
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import javax.swing.JComponent
 
 class ProjectSettingsConfigurable(
     project: Project
 ) : Configurable {
     private val stateService = project.service<ProjectSettings>()
-    private var enabledField: Cell<ComboBox<TriState>>? = null
+    private var enabledField: Cell<JBCheckBox>? = null
 
     override fun getDisplayName(): String {
         return Bundle.message("settings.title")
@@ -21,31 +20,22 @@ class ProjectSettingsConfigurable(
 
     override fun createComponent(): JComponent {
         return panel {
-            row(Bundle.message("settings.enable.label")) {
-                enabledField = comboBox(
-                    TriState.entries,
-                    textListCellRenderer {
-                        when (it) {
-                            TriState.ENABLED -> Bundle.message("settings.enable.enabled")
-                            TriState.DISABLED -> Bundle.message("settings.enable.disabled")
-                            else -> Bundle.message("settings.enable.undefined")
-                        }
-                    }
-                )
+            row {
+                enabledField = checkBox(Bundle.message("settings.enable.label"))
             }
         }
     }
 
     override fun isModified(): Boolean {
-        return this.enabledField!!.component.selectedItem as TriState? != stateService.state.enabled
+        return this.enabledField!!.component.isSelected != stateService.state.enabled
     }
 
     override fun apply() {
-        stateService.state.enabled = this.enabledField!!.component.selectedItem as TriState? ?: TriState.UNDEFINED
+        stateService.state.enabled = this.enabledField!!.component.isSelected
     }
 
     override fun reset() {
-        this.enabledField!!.component.selectedItem = stateService.state.enabled
+        this.enabledField!!.component.isSelected = stateService.state.enabled
 
         super.reset()
     }

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
@@ -1,0 +1,56 @@
+package me.sciberras.christian.pvs
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
+import javax.swing.JComponent
+
+class ProjectSettingsConfigurable(
+    private val project: Project
+) : Configurable {
+    private val stateService = project.service<ProjectSettings>()
+    private var initialState = this.stateService.state
+    private var currentState = ProjectSettingsState()
+
+    override fun getDisplayName(): String {
+        return "My Project Settings 2" // TODO this seems to be unused
+    }
+
+    override fun createComponent(): JComponent {
+        return panel {
+            row("Refresh language level") {
+                comboBox(
+                    TriState.entries,
+                    textListCellRenderer {
+                        when (it) {
+                            // TODO for localisation, use ApplicationBundle.message("combobox.insert.imports.ask")
+                            TriState.ENABLED -> "Yes"
+                            TriState.DISABLED -> "No"
+                            else -> ""
+                        }
+                    }
+                ).bindItem(currentState::enabled.toNullableProperty())
+            }
+        }
+    }
+
+    override fun isModified(): Boolean {
+        // TODO forced to true, so that the "Apply" button is clickable so we can see trigger the method below
+        return true; //this.currentState != this.initialState
+    }
+
+    override fun apply() {
+        // FIXME at this point, this.currentState.enabled should be what the user has selected, but it is never so
+        this.stateService.loadState(this.currentState)
+        this.initialState.copyFrom(this.currentState)
+    }
+
+    override fun reset() {
+        this.currentState.copyFrom(this.initialState)
+        super.reset()
+    }
+}

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
@@ -16,20 +16,19 @@ class ProjectSettingsConfigurable(
     private var enabledField: Cell<ComboBox<TriState>>? = null
 
     override fun getDisplayName(): String {
-        return "My Project Settings 2" // TODO this seems to be unused
+        return Bundle.message("settings.title")
     }
 
     override fun createComponent(): JComponent {
         return panel {
-            row("Refresh language level") {
+            row(Bundle.message("settings.enable.label")) {
                 enabledField = comboBox(
                     TriState.entries,
                     textListCellRenderer {
                         when (it) {
-                            // TODO for localisation, use ApplicationBundle.message("combobox.insert.imports.ask")
-                            TriState.ENABLED -> "Yes"
-                            TriState.DISABLED -> "No"
-                            else -> ""
+                            TriState.ENABLED -> Bundle.message("settings.enable.enabled")
+                            TriState.DISABLED -> Bundle.message("settings.enable.disabled")
+                            else -> Bundle.message("settings.enable.undefined")
                         }
                     }
                 )

--- a/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
+++ b/src/main/kotlin/me/sciberras/christian/pvs/ProjectSettingsConfigurable.kt
@@ -3,18 +3,17 @@ package me.sciberras.christian.pvs
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
-import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.builder.toNullableProperty
 import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import javax.swing.JComponent
 
 class ProjectSettingsConfigurable(
-    private val project: Project
+    project: Project
 ) : Configurable {
     private val stateService = project.service<ProjectSettings>()
-    private var initialState = this.stateService.state
-    private var currentState = ProjectSettingsState()
+    private var enabledField: Cell<ComboBox<TriState>>? = null
 
     override fun getDisplayName(): String {
         return "My Project Settings 2" // TODO this seems to be unused
@@ -23,7 +22,7 @@ class ProjectSettingsConfigurable(
     override fun createComponent(): JComponent {
         return panel {
             row("Refresh language level") {
-                comboBox(
+                enabledField = comboBox(
                     TriState.entries,
                     textListCellRenderer {
                         when (it) {
@@ -33,24 +32,22 @@ class ProjectSettingsConfigurable(
                             else -> ""
                         }
                     }
-                ).bindItem(currentState::enabled.toNullableProperty())
+                )
             }
         }
     }
 
     override fun isModified(): Boolean {
-        // TODO forced to true, so that the "Apply" button is clickable so we can see trigger the method below
-        return true; //this.currentState != this.initialState
+        return this.enabledField!!.component.selectedItem as TriState? != stateService.state.enabled
     }
 
     override fun apply() {
-        // FIXME at this point, this.currentState.enabled should be what the user has selected, but it is never so
-        this.stateService.loadState(this.currentState)
-        this.initialState.copyFrom(this.currentState)
+        stateService.state.enabled = this.enabledField!!.component.selectedItem as TriState? ?: TriState.UNDEFINED
     }
 
     override fun reset() {
-        this.currentState.copyFrom(this.initialState)
+        this.enabledField!!.component.selectedItem = stateService.state.enabled
+
         super.reset()
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,9 +18,10 @@
         <postStartupActivity implementation="me.sciberras.christian.pvs.ProjectActivity"/>
         <projectConfigurable
                 id="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
-                parentId="language"
+                parentId="reference.webide.settings.project.settings.php"
+                key="settings.title"
+                bundle="messages.PVSBundle"
                 instance="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
-                displayName="My Project Settings 1"
                 nonDefaultProject="false"/>
         <applicationService serviceImplementation="me.sciberras.christian.pvs.ProjectSettings"/>
     </extensions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,5 +16,12 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="me.sciberras.christian.pvs.ProjectActivity"/>
+        <projectConfigurable
+                id="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
+                parentId="language"
+                instance="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
+                displayName="My Project Settings 1"
+                nonDefaultProject="false"/>
+        <applicationService serviceImplementation="me.sciberras.christian.pvs.ProjectSettings"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,14 +15,27 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
-        <postStartupActivity implementation="me.sciberras.christian.pvs.ProjectActivity"/>
+        <postStartupActivity
+                implementation="me.sciberras.christian.pvs.PostProjectStartupActivity"
+        />
+        <backgroundPostStartupActivity
+                implementation="me.sciberras.christian.pvs.BackgroundPostProjectStartupActivity"
+        />
         <projectConfigurable
-                id="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
                 parentId="reference.webide.settings.project.settings.php"
                 key="settings.title"
                 bundle="messages.PVSBundle"
                 instance="me.sciberras.christian.pvs.ProjectSettingsConfigurable"
-                nonDefaultProject="false"/>
-        <applicationService serviceImplementation="me.sciberras.christian.pvs.ProjectSettings"/>
+                nonDefaultProject="false"
+        />
+        <applicationService
+                serviceImplementation="me.sciberras.christian.pvs.ProjectSettings"
+        />
+        <notificationGroup
+                id="PHP Version Switcher"
+                displayType="STICKY_BALLOON"
+                key="notifications.groupName"
+                bundle="messages.PVSBundle"
+        />
     </extensions>
 </idea-plugin>

--- a/src/main/resources/messages/PVSBundle.properties
+++ b/src/main/resources/messages/PVSBundle.properties
@@ -1,5 +1,7 @@
 settings.title=Version Switcher
-settings.enable.label=Refresh language level automatically:
-settings.enable.enabled=Yes
-settings.enable.disabled=No
-settings.enable.undefined=
+settings.enable.label=Switch language level automatically
+notifications.groupName=PHP version switcher
+notifications.enable.title=Project depends on different PHP versions
+notifications.enable.content=Enable <i>automatic version switching</i>?
+notifications.enable.enable=Yes, please!
+notifications.enable.ignore=Ignore

--- a/src/main/resources/messages/PVSBundle.properties
+++ b/src/main/resources/messages/PVSBundle.properties
@@ -1,0 +1,5 @@
+settings.title=Version Switcher
+settings.enable.label=Refresh language level automatically:
+settings.enable.enabled=Yes
+settings.enable.disabled=No
+settings.enable.undefined=


### PR DESCRIPTION
Fixes #3.

- [x] create & show tristate dropdown in settings
- [x] human-readable dropdown options
- [x] localized label and dropdown options (not sure how to provide the translations though)
- [x] persist settings across restarts
- [x] handle apply/reset properly
- ~~show the setting(s) in Settings->Languages & Frameworks->PHP (ideally after PHP "language level")~~
  This doesn't seem possible; it has to be something supported as an EP by `com.jetbrains.php.config.PhpProjectConfigurable` or `com.jetbrains.php.config.PhpProjectConfigurableForm`.
  Or perhaps at a higher level with the settings manager events.
- [x] when project is opened, if tristate setting is set to "undefined", check if project has different php versions (e.g. different composer files) and suggest enabling the setting
   - [x] show notification
   - [x] scan project